### PR TITLE
Updated setup.py  to not crash in Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,19 @@ for line in requirements:
 
 def check_python_version():
     """Exit when the Python version is too low."""
-    if sys.version < MINIMUM_PYTHON_VERSION:
-        sys.exit("Python {0}+ is required.".format(MINIMUM_PYTHON_VERSION))
+    
+    # get the version number, remove any trailing text, split into numerical values.
+    # then compare these sequences of numbers to one another
+    version = [int(v) for v in sys.version.split(' ')[0].split(".")]
+    min_version = [int(v) for v in MINIMUM_PYTHON_VERSION.split(' ')[0].split(".")]
+    for a,b in zip(version, min_version):
+        if a>b:
+            break
+        if a<b:
+           sys.exit("Python {0}+ is required.".format(MINIMUM_PYTHON_VERSION))
+        
+    
+    #if sys.version < MINIMUM_PYTHON_VERSION:
 
 
 def read_package_variable(key, filename="__init__.py"):


### PR DESCRIPTION
Originally it was just a string comparison which fails because  "3.10" < "3.6"